### PR TITLE
fix: test suite can run tests in parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-dev": "webpack --mode development",
     "build-prod": "webpack --mode production",
     "start": "webpack-dev-server --mode development & nodemon ./server/main.js",
-    "test": "jest"
+    "test": "NODE_ENV=test jest"
   },
   "repository": {
     "type": "git",

--- a/server/main.js
+++ b/server/main.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const musicRouter = require('./routes/music');
 const app = express();
 const PORT = 3000;
 
@@ -10,8 +11,14 @@ app.get('/', (req, res) => {
   res.status(200).end();
 })
 
-app.listen(PORT, (req, res) => {
-    console.log("Yay, express server is running on PORT 3000")
+app.use('/api/music', musicRouter);
+
+/* changes default behavior to "find first avaible port" in testing. This allows
+multiple tests to be run in paralell on different ports */
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, (req, res) => {
+      console.log("Yay, express server is running on PORT 3000")
   })
+}
 
 module.exports = app;


### PR DESCRIPTION
1. Updated script `npm test` to set `NODE_ENV = 'test'
2. Added an if statement to ignore `app.listen(PORT...)` when running tests

When a "listening port" is unspecified, the default behavior is to find the first available port. Jest can run tests in parallel this way on many ports. Previously, you would run into an `EADDRINUSE - port :3000 already in use` error.

[See here for more details](https://stackoverflow.com/questions/54422849/jest-testing-multiple-test-file-port-3000-already-in-use).